### PR TITLE
 Allow dependabot to update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        applies-to: version-updates
+        patterns:
+        - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
-      dependencies:
+      gha:
         applies-to: version-updates
         patterns:
         - "*"


### PR DESCRIPTION
Maybe this will apply org wide (to all repos) then the other PRs/configs aren't needed.